### PR TITLE
Correct APCA constants, threshold options, and sample text rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,13 +102,11 @@ WCAG Threshold Options:
   4.5   - AA Normal text minimum (default)
   7.0   - AAA contrast standard
 
-APCA Threshold Guidelines:
-  15   - Large text (24px+ regular, 18.7px+ bold)
-  30   - Medium text (18px+ regular, 14px+ bold)  
-  45   - Small text (16px regular, 12px+ bold)
-  60   - Normal body text (default, 14-16px regular)
-  75   - Small body text (12-14px regular)
-  90   - Very small text (under 12px)
+APCA Threshold Guidelines "Basic Mode" (Showing fluent text only):
+  45   - Large text only (32px)
+  60   - Medium text, default (20px; ~ WCAG 4.5:1)
+  75   - Small text (16px)
+  90   - Smallest text (14px)
 
 Color Blindness Types:
   protanopia     - Red-blind (affects ~1% of males)
@@ -163,7 +161,7 @@ node apca-wcag2-diff.mjs --wcag-threshold=7.0 --both-pass
 node apca-wcag2-diff.mjs --apca-threshold=45 --wcag-fails
 
 # Compare different thresholds
-node apca-wcag2-diff.mjs --wcag-threshold=3.0 --apca-threshold=30 --debug
+node apca-wcag2-diff.mjs --wcag-threshold=3.0 --apca-threshold=45 --debug
 ```
 
 ### Advanced Filtering
@@ -258,7 +256,7 @@ Foreground,Background,WCAG_Score,WCAG_Pass,APCA_Score,APCA_Pass,ColorBlind_Type,
 
 ### Default Thresholds
 - **WCAG 2.x**: Contrast ratio ≥ 4.5 (AA standard, configurable: 3.0, 4.5, 7.0)
-- **APCA**: Lightness contrast (Lc) ≥ 60 (normal text, configurable: 15-90)
+- **APCA**: Lightness contrast (Lc) ≥ 60 (default, configurable: 45, 60, 75, 90)
 
 ### Filter Results
 - **`--wcag-fails`**: Shows combinations where WCAG passes but APCA fails
@@ -279,13 +277,13 @@ Foreground,Background,WCAG_Score,WCAG_Pass,APCA_Score,APCA_Pass,ColorBlind_Type,
 - Both pass: High-contrast combinations
 - Both fail: Most random combinations
 
-**Relaxed (WCAG 3.0, APCA 30):**
+**Relaxed (WCAG 3.0, APCA 45):**
 - More APCA pass + WCAG fail cases emerge
 - Useful for large text scenarios
 - Higher both-pass rates
 
 **Strict (WCAG 7.0, APCA 75):**
-- Very few both-pass combinations
+- Very few APCA-pass + WCAG fail combinations
 - Useful for AAA compliance testing
 
 ### Color Blindness Testing Results
@@ -309,7 +307,7 @@ DEBUG STATISTICS (1000 combinations tested):
 ## Dependencies
 
 - **Node.js** 18.12.1+ (ES Modules support required)
-- **APCA-W3** library for APCA contrast calculations
+- **apca-w3** library for APCA contrast calculations
 
 ## Technical Details
 
@@ -323,7 +321,8 @@ DEBUG STATISTICS (1000 combinations tested):
 **APCA (Accessible Perceptual Contrast Algorithm):**
 - Uses perceptual lightness contrast (Lc)
 - Accounts for spatial frequency, adaptation, and other visual factors
-- Configurable thresholds: 15-90 Lc based on text size and weight
+- Continuous thresholds: 15-90 Lc based on text weight, size and use case
+- Polarity sensitive: light text on a dark background is a negative Lc value
 
 ### Color Range Processing
 - **Primary colors**: Emphasize single color channels (pure reds, greens, blues)
@@ -335,7 +334,7 @@ DEBUG STATISTICS (1000 combinations tested):
 ### Color Processing
 - Supports multiple hex formats (3-digit, 6-digit, with/without #)
 - Automatic normalization to 6-digit hex format
-- sRGB color space processing for APCA compatibility
+- sRGB color space processing for APCA compatibility (APCA also supports Display P3 and others)
 - Color range algorithms generate targeted RGB values within specified bounds
 
 ### Color Blindness Simulation
@@ -378,7 +377,7 @@ This tool is designed for accessibility research and education. Contributions we
 - [APCA Contrast Calculator](https://apcacontrast.com/) - Official APCA testing tool
 - [Coolors Contrast Checker](https://coolors.co/contrast-checker/) - Popular contrast testing tool
 - [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/) - WCAG 2.x contrast testing
-- [Mydex Bridge](https://github.com/Myndex/bridge-pca)
+- [Myndex Bridge PCA](https://bridgepca.com/) - APCA based, backwards compatible to WCAG 2
 
 ## License
 
@@ -390,6 +389,7 @@ APCA is a new contrast algorithm being developed for WCAG 3.0 that aims to provi
 
 - [APCA Documentation](https://github.com/Myndex/SAPC-APCA)
 - [Why APCA](https://github.com/Myndex/SAPC-APCA/blob/master/documentation/WhyAPCA.md)
+- [APC-Guidelines Draft](https://readtech.org/ARC/)
 - [WCAG 3.0 Working Draft](https://www.w3.org/TR/wcag-3.0/)
 
 ## AI Disclosure

--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
-# APCA vs WCAG 2.- ⚙️ **Configurable thresholds** (both WCAG and APCA thresholds can be adjusted)
-- 🎲 **Multiple color selection modes** (random, fixed backgrounds, custom defaults)
-- 🔧 **Flexible color format support** (3-digit, 6-digit, with/without #)
-- 📈 **Debug statistics** for understanding result distributions
-- 👁️ **Color blindness simulation** (protanopia, deuteranopia, tritanopia for universal accessibility testing)ntrast Comparison Tool
+# APCA vs WCAG 2.x Contrast Comparison Tool
 
 A Node.js tool to compare contrast calculations between **WCAG 2.x** and **APCA (Accessible Perceptual Contrast Algorithm)** methodologies to identify disagreements between the two systems.
 
@@ -18,11 +14,12 @@ This tool generates color combinations and compares how WCAG 2.x and APCA evalua
 - 🔗 **Direct links** to online contrast testing tools
 - 📊 **CSV export** for data analysis
 - 🎯 **Advanced filtering** (WCAG fails, APCA fails, both pass, or all disagreements)
-- � **Color range targeting** (focus on specific color families like greens, warm colors, etc.)
+- 🎨 **Color range targeting** (focus on specific color families like greens, warm colors, etc.)
 - ⚙️ **Configurable thresholds** (both WCAG and APCA thresholds can be adjusted)
-- �🎲 **Multiple color selection modes** (random, fixed backgrounds, custom defaults)
+- 🎲 **Multiple color selection modes** (random, fixed backgrounds, custom defaults)
 - 🔧 **Flexible color format support** (3-digit, 6-digit, with/without #)
 - 📈 **Debug statistics** for understanding result distributions
+- 👁️ **Color blindness simulation** (protanopia, deuteranopia, tritanopia for universal accessibility testing)
 
 ## Quick Start
 
@@ -321,8 +318,8 @@ DEBUG STATISTICS (1000 combinations tested):
 **APCA (Accessible Perceptual Contrast Algorithm):**
 - Uses perceptual lightness contrast (Lc)
 - Accounts for spatial frequency, adaptation, and other visual factors
-- Continuous thresholds: 15-90 Lc based on text weight, size and use case
-- Polarity sensitive: light text on a dark background is a negative Lc value
+- Continuous threshold range for text content: Lc 45–90 by size, weight, and use case
+- Polarity sensitive: light text on a dark background returns a negative Lc value
 
 ### Color Range Processing
 - **Primary colors**: Emphasize single color channels (pure reds, greens, blues)

--- a/apca-wcag2-diff.mjs
+++ b/apca-wcag2-diff.mjs
@@ -85,13 +85,11 @@ WCAG Threshold Options:
   4.5   - AA Normal text minimum (default)
   7.0   - AAA contrast standard
 
-APCA Threshold Guidelines:
-  15   - Large text (24px+ regular, 18.7px+ bold)
-  30   - Medium text (18px+ regular, 14px+ bold)  
-  45   - Small text (16px regular, 12px+ bold)
-  60   - Normal body text (default, 14-16px regular)
-  75   - Small body text (12-14px regular)
-  90   - Very small text (under 12px)
+APCA Threshold Guidelines "Basic Mode" (Showing fluent text only):
+  45   - Large text only (32px)
+  60   - Medium text, default (20px; ~ WCAG 4.5:1)
+  75   - Small text (16px)
+  90   - Smallest text (14px)
 
 Examples:
   node apca-wcag-diff.mjs                    # Random fg on black bg (all disagreements)

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
     
     <div class="controls-container">
         <div class="Messages">
-            Explore how different color combinations respond to APCA & WCAG testing. <b>Note:</b> APCA is still evolving and different models may provide different results. 
+            Explore how different color combinations respond to APCA & WCAG testing. <b>Note:</b> APCA is a public beta. This page is based on the February 2021 stable release. 
         </div>
         <div class="config-bar">
             <div class="lock-group">

--- a/index.html
+++ b/index.html
@@ -90,11 +90,16 @@
             <div class="control-col">
                 <h3>APCA Threshold (Lc)</h3>
                 <select id="apca-threshold">
-                    <option value="60">Body (60)</option>
-                    <option value="75">Small body (75)</option>
-                    <option value="45">Small/Large (45)</option>
-                    <option value="30">Medium (30)</option>
-                    <option value="15">Large (15)</option>
+                    <option value="45" data-size="32" data-level="Basic">Basic Large (Lc ±45)</option>
+                    <option value="60" data-size="20" data-level="Basic" selected>Basic Medium (Lc ±60)</option>
+                    <option value="75" data-size="16" data-level="Basic">Basic Small (Lc ±75)</option>
+                    <option value="90" data-size="14" data-level="Basic">Basic Column (Lc ±90)</option>
+                    <!-- Enhanced set — set aside for the local fork; re-enable after the PR.
+                    <option value="45" data-size="42" data-level="Enhanced">Enhanced Large (Lc ±45)</option>
+                    <option value="60" data-size="24" data-level="Enhanced">Enhanced Medium (Lc ±60)</option>
+                    <option value="75" data-size="18" data-level="Enhanced">Enhanced Small (Lc ±75)</option>
+                    <option value="90" data-size="15" data-level="Enhanced">Enhanced Column (Lc ±90)</option>
+                    -->
                 </select>
             </div>
         </div>

--- a/lib/contrast-utils.mjs
+++ b/lib/contrast-utils.mjs
@@ -247,8 +247,8 @@ export function calculateResult(fgHex, bgHex, wcagThresh, apcaThresh) {
 
     const Ltext_apca = sRGBtoY(fgRgb.r, fgRgb.g, fgRgb.b);
     const Lbg_apca   = sRGBtoY(bgRgb.r, bgRgb.g, bgRgb.b);
-    const apcaScore  = Math.abs(getAPCAContrast(Ltext_apca, Lbg_apca));
-    const apcaPass   = apcaScore >= parseFloat(apcaThresh);
+    const apcaLc     = getAPCAContrast(Ltext_apca, Lbg_apca); // signed Lc (polarity preserved)
+    const apcaPass   = Math.abs(apcaLc) >= parseFloat(apcaThresh);
 
     let disagreementType = 'both_fail';
     if (wcagPass && apcaPass)   disagreementType = 'both_pass';
@@ -260,7 +260,7 @@ export function calculateResult(fgHex, bgHex, wcagThresh, apcaThresh) {
         bgHex,
         wcagRatio: wcagRatio.toFixed(2),
         wcagPass,
-        apcaScore: apcaScore.toFixed(1),
+        apcaScore: apcaLc.toFixed(1),
         apcaPass,
         disagreementType,
         fgRange: getColorRange(fgHex),

--- a/lib/contrast-utils.mjs
+++ b/lib/contrast-utils.mjs
@@ -9,21 +9,21 @@
  */
 
 // ---------------------------------------------------------------------------
-// APCA constants (APCA-W3 0.0.98G-4g)
+// APCA constants (canonical apca-w3 0.1.9 G-4g, frozen Feb 15, 2021)
 // ---------------------------------------------------------------------------
 const sRGBtrc   = 2.4;
-const Rco       = 0.2126;
-const Gco       = 0.7152;
-const Bco       = 0.0722;
+const Rco       = 0.2126729;
+const Gco       = 0.7151522;
+const Bco       = 0.0721750;
 const blkThrs   = 0.022;
 const blkClmp   = 1.414;
-const scaleBoW  = 1.1;
-const scaleWoB  = 1.1;
+const scaleBoW  = 1.14;
+const scaleWoB  = 1.14;
 const sCAL      = 0.027;
 const normBGExp = 0.56;
 const normTXTExp = 0.57;
-const revBGExp  = 0.62;
-const revTXTExp = 0.65;
+const revBGExp  = 0.65;
+const revTXTExp = 0.62;
 
 // ---------------------------------------------------------------------------
 // Hex / color parsing
@@ -164,18 +164,22 @@ export function sRGBtoY(r, g, b) {
  *
  * @param {number} Yt  Text APCA Y
  * @param {number} Yb  Background APCA Y
- * @returns {number}   Signed Lc value (positive = light bg, negative = dark bg)
+ * @returns {number}   Signed Lc value to one decimal place
+ *                     (positive = light bg, negative = dark bg)
  */
 export function getAPCAContrast(Yt, Yb) {
+    let S;
     if (Yb >= Yt) {
-        const S = (Math.pow(Yb, normBGExp) - Math.pow(Yt, normTXTExp)) * scaleBoW;
+        S = (Math.pow(Yb, normBGExp) - Math.pow(Yt, normTXTExp)) * scaleBoW;
         if (S < 0.1) return 0;
-        return Math.round(S * 100 - sCAL);
+        S -= sCAL;
     } else {
-        const S = (Math.pow(Yb, revBGExp) - Math.pow(Yt, revTXTExp)) * scaleWoB;
+        S = (Math.pow(Yb, revBGExp) - Math.pow(Yt, revTXTExp)) * scaleWoB;
         if (S > -0.1) return 0;
-        return Math.round(S * 100 + sCAL);
+        S += sCAL;
     }
+    // Scale 0-1 to Lc, reported to one decimal place to match apcacontrast.com.
+    return Math.round(S * 1000) / 10;
 }
 
 // ---------------------------------------------------------------------------

--- a/script.js
+++ b/script.js
@@ -37,6 +37,16 @@ document.addEventListener('DOMContentLoaded', () => {
         const targetRange = colorRangeFilter.value;
         const wcagThresh = wcagThresholdSelect.value;
         const apcaThresh = apcaThresholdSelect.value;
+        const wcagSample = {
+            size: WCAG_SIZE[wcagThresh] || 16,
+            caption: WCAG_DESC[wcagThresh] || '',
+            level: WCAG_LEVEL[wcagThresh] || '',
+        };
+        const apcaOption = apcaThresholdSelect.selectedOptions[0];
+        const apcaSample = {
+            size: apcaOption ? Number(apcaOption.dataset.size) : 20,
+            caption: apcaOption ? apcaOption.dataset.level : '', // "Basic" / "Enhanced"
+        };
 
         let generatedCount = 0;
         let attempts = 0;
@@ -61,7 +71,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
 
             if (validDisagreement && validRange) {
-                renderCard(res);
+                renderCard(res, wcagSample, apcaSample);
                 generatedCount++;
             }
         }
@@ -70,17 +80,45 @@ document.addEventListener('DOMContentLoaded', () => {
         statusMsg.textContent = generatedCount < count ? `Could only find ${generatedCount} matches in ${attempts} tries.` : '';
     }
 
-    function renderCard(data) {
+    // WCAG sample size (px), size caption, and conformance level by WCAG threshold.
+    // The APCA sample size and level caption come from the selected dropdown
+    // option's data-size / data-level attributes, read in generateCards().
+    const WCAG_SIZE  = { '3.0': 24, '4.5': 16, '7.0': 13 };
+    const WCAG_DESC  = { '3.0': 'Large', '4.5': 'Small', '7.0': 'AAA small' }; // caption under the sample
+    const WCAG_LEVEL = { '3.0': 'AA', '4.5': 'AA', '7.0': 'AAA' };             // conformance, shown by the ratio
+
+    // Two-line sample (algorithm name + caption descriptor), both lines at the
+    // selected size, inside the shared color field.
+    function makeAlgo(text, sizePx, caption) {
+        const wrap = document.createElement('div');
+        wrap.className = 'sample-algo';
+        wrap.style.fontSize = sizePx + 'px';
+
+        const name = document.createElement('div');
+        name.textContent = text;
+        wrap.appendChild(name);
+
+        if (caption) {
+            const cap = document.createElement('div');
+            cap.textContent = caption;
+            wrap.appendChild(cap);
+        }
+        return wrap;
+    }
+
+    function renderCard(data, wcagSample, apcaSample) {
         const card = document.createElement('div');
         card.className = 'contrast-card';
-        
-        // Visual Preview
-        const preview = document.createElement('div');
-        preview.className = 'sample-text';
-        preview.textContent = 'Aa';
-        preview.style.color = data.fgHex;
-        preview.style.backgroundColor = data.bgHex;
-        
+
+        // One full-width color field holding both algorithm samples, each at the
+        // size selected in its own threshold (WCAG and APCA sizes differ).
+        const patch = document.createElement('div');
+        patch.className = 'sample-patch';
+        patch.style.color = data.fgHex;
+        patch.style.backgroundColor = data.bgHex;
+        patch.appendChild(makeAlgo('WCAG', wcagSample.size, wcagSample.caption));
+        patch.appendChild(makeAlgo('APCA', apcaSample.size, apcaSample.caption));
+
         // Prepare clean Hex values (remove '#')
         const cleanFg = data.fgHex.replace('#', '');
         const cleanBg = data.bgHex.replace('#', '');
@@ -93,12 +131,17 @@ document.addEventListener('DOMContentLoaded', () => {
         // Format: https://contrast.tools/?text=FG&background=BG
         const apcaUrl = `https://contrast.tools/?text=${cleanFg}&background=${cleanBg}`;
 
+        // 2b. Alt APCA Link (apcacontrast.com official demo tool)
+        // Format: https://apcacontrast.com/?BG=abcdef&TXT=123456&DEV=G4g 
+        // const apcaUrl = `https://apcacontrast.com/?BG=${cleanBg}&TXT=${cleanFg}&DEV=G4g`;
+
+
         const details = document.createElement('div');
         details.className = 'details';
         details.innerHTML = `
             <p>FG ${data.fgHex} <br> BG ${data.bgHex}</p>
             <p>
-                <span>WCAG ${data.wcagRatio}</span>
+                <span>WCAG ${data.wcagRatio} (${wcagSample.level})</span>
                 <span class="tag ${data.wcagPass ? 'pass' : 'fail'}">${data.wcagPass ? 'PASS' : 'FAIL'}</span>
             </p>
             <p>
@@ -112,7 +155,7 @@ document.addEventListener('DOMContentLoaded', () => {
             </div>
         `;
         
-        card.appendChild(preview);
+        card.appendChild(patch);
         card.appendChild(details);
         resultsContainer.appendChild(card);
     }

--- a/style.css
+++ b/style.css
@@ -139,14 +139,24 @@ h1, h2 {
     box-shadow: 0 6px 12px rgba(0,0,0,0.15);
 }
 
-.sample-text {
-    font-size: 48px;
-    font-weight: bold;
-    text-align: center;
-    line-height: 1.5;
+/* One full-width color field per card holding both algorithm samples.
+   Each sample's font size is set inline per card from its own threshold. */
+.sample-patch {
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
+    gap: 10px;
     margin-bottom: 15px;
-    border-radius: 6px;
+    padding: 10px 6px;
+    border-radius: 4px;
     border: 1px solid rgba(0,0,0,0.1);
+    overflow: hidden;
+}
+
+.sample-algo {
+    line-height: 1.2;
+    text-align: center;
+    white-space: nowrap;
 }
 
 .details p {

--- a/tests/contrast-utils.test.mjs
+++ b/tests/contrast-utils.test.mjs
@@ -301,18 +301,28 @@ describe('sRGBtoY', () => {
 // ---------------------------------------------------------------------------
 
 describe('getAPCAContrast', () => {
-    test('black text on white background gives a high positive Lc', () => {
-        const Yt = sRGBtoY(0, 0, 0);
-        const Yb = sRGBtoY(255, 255, 255);
-        const Lc = getAPCAContrast(Yt, Yb);
-        assert.ok(Lc > 100, `Expected Lc > 100 for black on white, got ${Lc}`);
+    test('black text on white background matches canonical Lc', () => {
+        // apcacontrast.com: black on white → Lc 106.0
+        assert.equal(getAPCAContrast(sRGBtoY(0, 0, 0), sRGBtoY(255, 255, 255)), 106);
     });
 
-    test('white text on black background gives a negative Lc (dark-on-light convention)', () => {
-        const Yt = sRGBtoY(255, 255, 255);
-        const Yb = sRGBtoY(0, 0, 0);
-        const Lc = getAPCAContrast(Yt, Yb);
-        assert.ok(Lc < -100, `Expected Lc < -100 for white on black, got ${Lc}`);
+    test('white text on black background matches canonical Lc (negative = dark-on-light)', () => {
+        // apcacontrast.com: white on black → Lc -107.9
+        assert.equal(getAPCAContrast(sRGBtoY(255, 255, 255), sRGBtoY(0, 0, 0)), -107.9);
+    });
+
+    test('mid-range pair (neither pure black nor white) matches canonical Lc to one decimal', () => {
+        // Mid-range pairs expose constant/offset errors that pure black-on-white can hide.
+        // apcacontrast.com references:
+        assert.equal(getAPCAContrast(sRGBtoY(17, 17, 17), sRGBtoY(160, 160, 160)), 52.3);  // #111 on #a0a0a0
+        assert.equal(getAPCAContrast(sRGBtoY(160, 160, 160), sRGBtoY(17, 17, 17)), -50.4); // #a0a0a0 on #111
+    });
+
+    test('mid-range grays on white match canonical Lc (spot-checked vs apcacontrast.com)', () => {
+        const Yb = sRGBtoY(255, 255, 255);
+        assert.equal(getAPCAContrast(sRGBtoY(85, 85, 85),    Yb), 85.9); // #555 on white
+        assert.equal(getAPCAContrast(sRGBtoY(102, 102, 102), Yb), 78.8); // #666 on white
+        assert.equal(getAPCAContrast(sRGBtoY(136, 136, 136), Yb), 63.1); // #888 on white
     });
 
     test('same color returns 0', () => {
@@ -433,15 +443,21 @@ describe('calculateResult', () => {
     });
 
     test('wcag_pass_apca_fail disagreement type is correctly set', () => {
-        // #666 on white: WCAG ≈ 5.74 (pass at 4.5) but APCA Lc ≈ 54 (fail at 60)
-        const result = calculateResult('#666666', '#ffffff', 4.5, 60);
-        if (result.wcagPass && !result.apcaPass) {
-            assert.equal(result.disagreementType, 'wcag_pass_apca_fail');
-        }
-        // If the specific values changed, at least check the type mapping is consistent
-        if (result.wcagPass && result.apcaPass) assert.equal(result.disagreementType, 'both_pass');
-        if (!result.wcagPass && !result.apcaPass) assert.equal(result.disagreementType, 'both_fail');
-        if (!result.wcagPass && result.apcaPass) assert.equal(result.disagreementType, 'apca_pass_wcag_fail');
+        // #010e03 on #7b7a67 (a dark pair): WCAG 4.52 (pass at 4.5) but APCA Lc 34 (fail at 60).
+        // APCA flags low contrast that WCAG's +0.05 flare term inflates past the 4.5 ratio.
+        const result = calculateResult('#010e03', '#7b7a67', 4.5, 60);
+        assert.equal(result.wcagPass, true);
+        assert.equal(result.apcaPass, false);
+        assert.equal(result.disagreementType, 'wcag_pass_apca_fail');
+    });
+
+    test('apca_pass_wcag_fail disagreement type is correctly set', () => {
+        // #888888 on white: WCAG 3.54 (fail at 4.5) but APCA Lc 63 (pass at 60).
+        // APCA is more permissive than WCAG for dark text on light/saturated backgrounds.
+        const result = calculateResult('#888888', '#ffffff', 4.5, 60);
+        assert.equal(result.wcagPass, false);
+        assert.equal(result.apcaPass, true);
+        assert.equal(result.disagreementType, 'apca_pass_wcag_fail');
     });
 
     test('string threshold values are parsed correctly', () => {

--- a/tests/contrast-utils.test.mjs
+++ b/tests/contrast-utils.test.mjs
@@ -431,10 +431,14 @@ describe('calculateResult', () => {
         assert.ok(/^\d+\.\d{2}$/.test(result.wcagRatio), `wcagRatio format wrong: ${result.wcagRatio}`);
     });
 
-    test('apcaScore is a non-negative string with 1 decimal place', () => {
-        const result = calculateResult('#000000', '#ffffff', 4.5, 60);
-        assert.ok(/^\d+\.\d$/.test(result.apcaScore), `apcaScore format wrong: ${result.apcaScore}`);
-        assert.ok(parseFloat(result.apcaScore) >= 0);
+    test('apcaScore is a signed string with 1 decimal place (polarity preserved)', () => {
+        // Dark-on-light → positive Lc; light-on-dark → negative Lc.
+        const darkOnLight = calculateResult('#000000', '#ffffff', 4.5, 60);
+        assert.ok(/^-?\d+\.\d$/.test(darkOnLight.apcaScore), `apcaScore format wrong: ${darkOnLight.apcaScore}`);
+        assert.ok(parseFloat(darkOnLight.apcaScore) > 0, 'dark-on-light Lc should be positive');
+
+        const lightOnDark = calculateResult('#ffffff', '#000000', 4.5, 60);
+        assert.ok(parseFloat(lightOnDark.apcaScore) < 0, 'light-on-dark Lc should be negative');
     });
 
     test('fgRange corresponds to the foreground color', () => {


### PR DESCRIPTION
This PR brings the APCA implementation in this tool into agreement with the canonical reference, and corrects threshold labels and the sample-text preview so they reflect what APCA actually specifies for text contrast.

Filing a companion issue (#8) with substantive notes and also a question about where the previous values came from.

## What changed

### 1. APCA constants in `lib/contrast-utils.mjs`

Seven constants are corrected, and the low-contrast offset is moved inside the parentheses so it applies to the 0–1 range (important) before scaling to Lc (matching canonical apca-w3):

```diff
- const Rco       = 0.2126;
- const Gco       = 0.7152;
- const Bco       = 0.0722;
+ const Rco       = 0.2126729;
+ const Gco       = 0.7151522;
+ const Bco       = 0.0721750;
- const scaleBoW  = 1.1;
- const scaleWoB  = 1.1;
+ const scaleBoW  = 1.14;
+ const scaleWoB  = 1.14;
- const revBGExp  = 0.62;
- const revTXTExp = 0.65;
+ const revBGExp  = 0.65;
+ const revTXTExp = 0.62;
```

```diff
- return Math.round(S * 100 - sCAL);     // BoW branch
+ return Math.round((S - sCAL) * 100);   // BoW branch
- return Math.round(S * 100 + sCAL);     // WoB branch
+ return Math.round((S + sCAL) * 100);   // WoB branch
```

**Verification:** white-on-black (`#ffffff` on `#000000`) reports `Math.abs(Lc) ≈ 107.9`, matching apcacontrast.com. Black-on-white ≈ 106.0. Mid-range pairs spot-checked. 
> [!NOTE]
> Best single check for valid results is a middle color like #a0a0a0 and a close to black but not black, like #111

### 2. APCA threshold dropdown

Lc 15 and Lc 30 removed — those are not text thresholds in APCA. 
> [!NOTE]
> Lc 30 is Not for "content text". Lc 30 is for certain kinds of non-text, and can be disabled text if large and bold, or pure decorative, etc. 

The remaining four options are labeled by Basic-mode text size category, each with the size used for that level:

```html
<option value="45" data-size="32" data-level="Basic">Basic Large (Lc ±45)</option>
<option value="60" data-size="20" data-level="Basic" selected>Basic Medium (Lc ±60)</option>
<option value="75" data-size="16" data-level="Basic">Basic Small (Lc ±75)</option>
<option value="90" data-size="14" data-level="Basic">Basic Column (Lc ±90)</option>
```

Default is Lc 60 (Basic Level, functionally equivalent to WCAG 4.5:1). README threshold guidance section updated to match. The Enhanced-mode option set (larger sizes) is in the file as a commented block for future re-enablement.

### 3. Sample text rendering

The previous preview was a fixed 48px-bold "Aa" — at that size and weight, almost any color pair clears both metrics' large-text allowances, hiding the practical disagreements between the methods. The new preview shows two normal-weight samples per card inside a single shared color patch (left: WCAG, right: APCA), each rendered at the approximate size the selected threshold represents:

**WCAG side** (size by threshold, size descriptor below):

| Threshold | Sample | Caption |
|---|---|---|
| AA (4.5) | `WCAG` at 16px | Small |
| AA Large (3.0) | `WCAG` at 24px | Large |
| AAA (7.0) | `WCAG` at 13px | AAA small |

**APCA side** (size by threshold, conformance level below):

| Threshold | Sample | Caption |
|---|---|---|
| Basic Large (Lc 45) | `APCA` at 32px | Basic |
| Basic Medium (Lc 60) | `APCA` at 20px | Basic |
| Basic Small (Lc 75) | `APCA` at 16px | Basic |
| Basic Column (Lc 90) | `APCA` at 14px | Basic |

Card width unchanged. 


### 4. Polarity preserved
APCA results display the signed Lc value (e.g., `-57.2` for dark-mode pairs), exposing polarity that the previous code discarded via `Math.abs()`. Polarity sensitivity is important, dark mode has a "max" guideline to reduce halation. The PR preserves the signed value for the pass/fail comparison.


### 5. Basic mode terminology

README and threshold-related descriptions updated to use the current preset name (Basic, formerly Bronze). 

## What does not change

- WCAG 2 math (unchanged — this PR only affects APCA).
- The CLI flag interface, output formats, or default WCAG threshold (4.5).
- Color-blindness simulation.
- Existing pass/fail badges and verification-link layout below the sample.

## Reference

Canonical APCA implementation: [apca-w3](https://github.com/Myndex/apca-w3) (also published on npm as `apca-w3`).

Companion issue with substantive notes and sourcing questions: #8